### PR TITLE
Only parse a file if it contains a target module.

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,12 @@ module.exports = function parse (modules, opts) {
     return duplexer(concat(function (buf) {
         try {
             body = buf.toString('utf8').replace(/^#!/, '//#!');
-            falafel(body, { ecmaVersion: 6 }, walk);
+
+            for (var key in modules) {
+              if (body.indexOf(key) === -1) continue;
+              falafel(body, { ecmaVersion: 6 }, walk);
+              break;
+            }
         }
         catch (err) { return error(err) }
         finish(body);

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "through2": "~0.4.1"
   },
   "devDependencies": {
+    "from2-string": "^1.1.0",
     "resolve": "^1.1.5",
     "tape": "^3.4.0"
   },

--- a/test/limit-parsing.js
+++ b/test/limit-parsing.js
@@ -1,0 +1,23 @@
+var concat = require('concat-stream');
+var from = require('from2-string');
+var staticModule = require('../');
+var test = require('tape');
+
+test('limit parsing to files including a target module', function (t) {
+  var passInput = 'THIS WILL NOT PARSE';
+  var failInput = passInput + '; require("fs")';
+
+  t.plan(2);
+
+  from(passInput)
+    .pipe(staticModule({ fs: require('fs') }))
+    .pipe(concat(function (passOutput) {
+      t.equal(passInput, String(passOutput), 'does not parse');
+    }));
+
+  from(failInput)
+    .pipe(staticModule({ fs: require('fs') }))
+    .once('error', function () {
+      t.pass('parses if module is included');
+    });
+});


### PR DESCRIPTION
This speeds up bundle times, and prevents syntax errors being raised prematurely – e.g. if JSX is being used in another part of the app, and the static-module transform is not necessary there.

Thanks! :)