### PR TITLE
keep require when module usage is dynamic

### DIFF
--- a/test/dynamic.js
+++ b/test/dynamic.js
@@ -1,0 +1,39 @@
+var test = require('tape');
+var concat = require('concat-stream');
+var quote = require('quote-stream');
+var staticModule = require('../');
+var fs = require('fs');
+var path = require('path');
+
+test('dynamic modules', function (t) {
+    t.plan(1);
+    
+    var dirname = path.join(__dirname, 'dynamic');
+    var expected = [ 'beep boop!' ];
+    var sm = staticModule({
+        fs: {
+            readFileSync: function (file, enc) {
+                return fs.createReadStream(file).pipe(quote());
+            }
+        }
+    }, {
+        vars: { __dirname: dirname },
+        varModules: { path: require('path') }
+    });
+    
+    readStream('source.js').pipe(sm).pipe(concat(function (body) {
+        t.equal(
+            body.toString('utf8'),
+            'var fs = require(\'fs\');'
+            + '\nvar path = require(\'path\');'
+            + '\nvar file = path.join(__dirname, \'source.js\');'
+            + '\nvar source = fs.readFileSync(file, \'utf8\');\n'
+        );
+        Function(['console','require', '__dirname'],body)({ log: log },require,dirname);
+        function log (msg) { t.equal(msg, expected.shift()) }
+    }));
+});
+
+function readStream (file) {
+    return fs.createReadStream(path.join(__dirname, 'dynamic', file));
+}

--- a/test/dynamic/source.js
+++ b/test/dynamic/source.js
@@ -1,0 +1,4 @@
+var fs = require('fs');
+var path = require('path');
+var file = path.join(__dirname, 'source.js');
+var source = fs.readFileSync(file, 'utf8');


### PR DESCRIPTION
for example, when using [`css-extract`](https://github.com/stackcss/css-extract/) (which uses `static-module` under the hood), the following source:

```js
var style = require('./style');
var insertCSS = require('insert-css');

insertCSS(style);
```

is transformed to:

```js
var style = require('./style');

insertCSS(style);
```

so even though `static-eval` was unable to evaluate the expression `insertCss(style)`, `static-module` still removed `var insertCss = require('insert-css')`.

this pull request fixes that use case and adds a test for this behavior.

all the existing tests pass, but i feel like i added some terrible hacks, so feedback is very welcome. :cat:

this is related to https://github.com/yoshuawuyts/bankai/issues/109.