### PR TITLE
update static-eval, closes #34, #35

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: node_js
 node_js:
-  - "0.8"
+  - 9
+  - 8
+  - 6
+  - 4 
   - "0.10"

--- a/index.js
+++ b/index.js
@@ -307,7 +307,9 @@ module.exports = function parse (modules, opts) {
                     return evaluate(arg, xvars);
                 });
 
-                res = callee.apply(null, args)
+                if (callee !== undefined) {
+                    res = callee.apply(null, args);
+                }
             }
 
             if (res !== undefined) {

--- a/index.js
+++ b/index.js
@@ -287,8 +287,29 @@ module.exports = function parse (modules, opts) {
             
             var xvars = copy(vars);
             xvars[node.name] = val;
-            
+
             var res = evaluate(cur, xvars);
+            if (res === undefined && cur.type === 'CallExpression') {
+                // static-eval can't safely evaluate code with callbacks, so do it manually in a safe way
+                var callee = evaluate(cur.callee, xvars);
+                var args = cur.arguments.map(function (arg) {
+                    // Return a function stub for callbacks so that `static-module` users
+                    // can do `callback.toString()` and get the original source
+                    if (arg.type === 'FunctionExpression' || arg.type === 'ArrowFunctionExpression') {
+                        var fn = function () {
+                            throw new Error('static-module: cannot call callbacks defined inside source code');
+                        };
+                        fn.toString = function () {
+                            return body.slice(arg.start, arg.end);
+                        };
+                        return fn;
+                    }
+                    return evaluate(arg, xvars);
+                });
+
+                res = callee.apply(null, args)
+            }
+
             if (res !== undefined) {
                 updates.push({
                     start: cur.start,

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "quote-stream": "~1.0.2",
     "readable-stream": "~2.3.3",
     "shallow-copy": "~0.0.1",
-    "static-eval": "~0.2.0",
+    "static-eval": "^2.0.0",
     "through2": "~2.0.3"
   },
   "devDependencies": {


### PR DESCRIPTION
builds on #35, but when static-eval cannot evaluate a callback function
because it is unsafe, this passes a proxy value. when the proxy callback
function is called, it throws an error, but when it is stringified (eg
in the generated output) it'll work.

this works with brfs, i haven't tried others yet.

e; css-extract works.