### PR TITLE
Catch errors in statically evaluated expressions

### DIFF
--- a/index.js
+++ b/index.js
@@ -308,7 +308,11 @@ module.exports = function parse (modules, opts) {
                 });
 
                 if (callee !== undefined) {
-                    res = callee.apply(null, args);
+                    try {
+                        res = callee.apply(null, args);
+                    } catch (err) {
+                        // Evaluate to undefined
+                    }
                 }
             }
 


### PR DESCRIPTION
This will just not replace expressions that cannot be evaluated because
of a runtime error.

This is needed for https://github.com/browserify/brfs/pull/83 which
fixes https://github.com/browserify/brfs/issues/81.