### PR TITLE
Source maps, fixes #2

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,11 +5,13 @@
   "main": "index.js",
   "dependencies": {
     "concat-stream": "~1.6.0",
+    "convert-source-map": "^1.5.1",
     "duplexer2": "~0.1.4",
     "escodegen": "~1.9.0",
     "falafel": "^2.1.0",
     "has": "^1.0.1",
     "magic-string": "^0.22.4",
+    "merge-source-map": "1.0.4",
     "object-inspect": "~1.4.0",
     "quote-stream": "~1.0.2",
     "readable-stream": "~2.3.3",
@@ -18,10 +20,10 @@
     "through2": "~2.0.3"
   },
   "devDependencies": {
-    "convert-source-map": "^1.5.1",
     "resolve": "^1.5.0",
     "source-map": "^0.6.1",
-    "tape": "^4.8.0"
+    "tape": "^4.8.0",
+    "uglify-js": "3.3.12"
   },
   "scripts": {
     "test": "tape test/*.js"

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "escodegen": "~1.9.0",
     "falafel": "^2.1.0",
     "has": "^1.0.1",
+    "magic-string": "^0.22.4",
     "object-inspect": "~1.4.0",
     "quote-stream": "~1.0.2",
     "readable-stream": "~2.3.3",
@@ -17,7 +18,9 @@
     "through2": "~2.0.3"
   },
   "devDependencies": {
+    "convert-source-map": "^1.5.1",
     "resolve": "^1.5.0",
+    "source-map": "^0.6.1",
     "tape": "^4.8.0"
   },
   "scripts": {

--- a/readme.markdown
+++ b/readme.markdown
@@ -100,6 +100,10 @@ process.stdin.pipe(sm).pipe(process.stdout);
 Use `opts.parserOpts` to set additional options for the
 [acorn](https://github.com/acornjs/acorn) parser.
 
+Set `opts.sourceMap` to `true` to generate a source map and add it as an inline
+comment. You can add `opts.inputFilename` to configure the original file name
+that will be listed in the source map.
+
 # install
 
 With [npm](https://npmjs.org) do:

--- a/test/sourcemap.js
+++ b/test/sourcemap.js
@@ -4,6 +4,7 @@ var concat = require('concat-stream');
 var PassThrough = require('stream').PassThrough;
 var convertSourceMap = require('convert-source-map');
 var SourceMapConsumer = require('source-map').SourceMapConsumer;
+var uglify = require('uglify-js');
 var staticModule = require('../');
 
 test('source maps', function (t) {
@@ -17,7 +18,7 @@ test('source maps', function (t) {
             stream.end('}`');
             return stream;
         }
-    }, { sourceMap: true });
+    }, { sourceMap: true, inputFilename: 'main.js' });
 
     fs.createReadStream(__dirname + '/sourcemap/main.js').pipe(transform).pipe(concat({ encoding: 'string' }, function (res) {
         var consumer = new SourceMapConsumer(convertSourceMap.fromSource(res).toObject());
@@ -43,4 +44,45 @@ test('source maps', function (t) {
         t.equal(mapped.line, 10);
         t.equal(mapped.column, 0);
     }));
+});
+
+test('input source map', function (t) {
+    t.plan(4);
+
+    var content = fs.readFileSync(__dirname + '/sourcemap/main.js', 'utf8');
+    var minified = uglify.minify({ 'main.js': content }, {
+        output: { beautify: true },
+        sourceMap: {
+            url: 'inline',
+            includeSources: true
+        }
+    });
+
+    var transform = staticModule({
+        sheetify: function (filename) {
+            var stream = PassThrough();
+            stream.end('`.css{\n  color: orange;\n}`');
+            return stream;
+        }
+    }, { sourceMap: true, inputFilename: 'main.js' });
+
+    transform.pipe(concat({ encoding: 'string' }, function (res) {
+        var consumer = new SourceMapConsumer(convertSourceMap.fromSource(res).toObject());
+
+        var mapped = consumer.originalPositionFor({
+            line: 7,
+            column: 0
+        });
+        t.equal(mapped.line, 8);
+        t.equal(mapped.column, 0);
+
+        mapped = consumer.originalPositionFor({
+            line: 9,
+            column: 4
+        });
+        t.equal(mapped.line, 10);
+        t.equal(mapped.column, 0);
+    }));
+
+    transform.end(minified.code);
 });

--- a/test/sourcemap.js
+++ b/test/sourcemap.js
@@ -1,0 +1,46 @@
+var test = require('tape');
+var fs = require('fs');
+var concat = require('concat-stream');
+var PassThrough = require('stream').PassThrough;
+var convertSourceMap = require('convert-source-map');
+var SourceMapConsumer = require('source-map').SourceMapConsumer;
+var staticModule = require('../');
+
+test('source maps', function (t) {
+    t.plan(6);
+
+    var transform = staticModule({
+        sheetify: function (filename) {
+            var stream = PassThrough();
+            stream.write('`.css{\n');
+            stream.write('  color: red;\n');
+            stream.end('}`');
+            return stream;
+        }
+    }, { sourceMap: true });
+
+    fs.createReadStream(__dirname + '/sourcemap/main.js').pipe(transform).pipe(concat({ encoding: 'string' }, function (res) {
+        var consumer = new SourceMapConsumer(convertSourceMap.fromSource(res).toObject());
+
+        var mapped = consumer.originalPositionFor({
+            line: 8,
+            column: 0
+        });
+        t.equal(mapped.line, 8);
+        t.equal(mapped.column, 0);
+
+        mapped = consumer.originalPositionFor({
+            line: 10,
+            column: 2
+        });
+        t.equal(mapped.line, 8);
+        t.equal(mapped.column, 19);
+
+        mapped = consumer.originalPositionFor({
+            line: 12,
+            column: 0
+        });
+        t.equal(mapped.line, 10);
+        t.equal(mapped.column, 0);
+    }));
+});

--- a/test/sourcemap/main.js
+++ b/test/sourcemap/main.js
@@ -1,0 +1,10 @@
+var css = require('sheetify');
+
+function doSomeStuff () {
+    // doing some stuff before inlining a static module call
+    return yadda(yadda)
+}
+
+css('filename.css');
+
+exports.blah = whatever.xyz


### PR DESCRIPTION
Use magic-string for source map generation. Magic-string can also handle
string replacements but static-module already does that well with
streams. This patch only uses the source map generation capabilities of
magic-string.

If the source string contains a source mapping comment, the static-module
changes are merged into it, so the final source map points back to the
original source.

Source maps are opt in using the `sourceMap: true` option.