### PR TITLE
Only parse a file if it contains a target module. (rebased)

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,7 +39,12 @@ module.exports = function parse (modules, opts) {
                 body = convertSourceMap.removeComments(body);
                 sourcemapper = new MagicString(body);
             }
-            falafel(body, parserOpts, walk);
+
+            for (var key in modules) {
+                if (body.indexOf(key) === -1) continue;
+                falafel(body, parserOpts, walk);
+                break;
+            }
         }
         catch (err) { return error(err) }
         finish(body);

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "through2": "~2.0.3"
   },
   "devDependencies": {
+    "from2-string": "^1.1.0",
     "resolve": "^1.5.0",
     "source-map": "^0.6.1",
     "tape": "^4.8.0",

--- a/test/limit-parsing.js
+++ b/test/limit-parsing.js
@@ -1,0 +1,23 @@
+var concat = require('concat-stream');
+var from = require('from2-string');
+var staticModule = require('../');
+var test = require('tape');
+
+test('limit parsing to files including a target module', function (t) {
+  var passInput = 'THIS WILL NOT PARSE';
+  var failInput = passInput + '; require("fs")';
+
+  t.plan(2);
+
+  from(passInput)
+    .pipe(staticModule({ fs: require('fs') }))
+    .pipe(concat(function (passOutput) {
+      t.equal(passInput, String(passOutput), 'does not parse');
+    }));
+
+  from(failInput)
+    .pipe(staticModule({ fs: require('fs') }))
+    .once('error', function () {
+      t.pass('parses if module is included');
+    });
+});


### PR DESCRIPTION
Closes #20 

Only parse a file if it contains a target module.

This speeds up bundle times, and prevents syntax errors being
raised prematurely – e.g. if JSX is being used in another
part of the app, and the static-module transform is not
necessary there.