### PR TITLE
Handle empty files

### DIFF
--- a/test/brfs.js
+++ b/test/brfs.js
@@ -27,6 +27,20 @@ test('readFileSync', function (t) {
     }));
 });
 
+test('readFileSync empty', function (t) {
+    t.plan(1);
+    var sm = staticModule({
+        fs: {
+            readFileSync: function (file) {
+                return fs.createReadStream(file).pipe(quote());
+            }
+        }
+    }, { vars: { __dirname: path.join(__dirname, 'brfs') } });
+    readStream('empty.js').pipe(sm).pipe(concat(function (body) {
+        t.equal(body.toString('utf8'), '');
+    }));
+});
+
 test('readFileSync attribute', function (t) {
     t.plan(2);
     var sm = staticModule({


### PR DESCRIPTION
Fix so that static-module handles empty files.

Without this fix, reading an empty file leads to an error like this:

```
TypeError: Invalid non-string/buffer chunk
    at validChunk (/Users/arve/Projects/static-module/node_modules/readable-stream/lib/_stream_writable.js:304:10)
    at DestroyableTransform.Writable.write (/Users/arve/Projects/static-module/node_modules/readable-stream/lib/_stream_writable.js:332:62)
    at DestroyableTransform.Writable.end (/Users/arve/Projects/static-module/node_modules/readable-stream/lib/_stream_writable.js:585:51)
    at /Users/arve/Projects/static-module/index.js:46:24
    at ConcatStream.<anonymous> (/Users/arve/Projects/static-module/node_modules/concat-stream/index.js:37:43)
    at ConcatStream.emit (events.js:185:15)
    at finishMaybe (/Users/arve/Projects/static-module/node_modules/readable-stream/lib/_stream_writable.js:630:14)
    at endWritable (/Users/arve/Projects/static-module/node_modules/readable-stream/lib/_stream_writable.js:638:3)
    at ConcatStream.Writable.end (/Users/arve/Projects/static-module/node_modules/readable-stream/lib/_stream_writable.js:594:41)
    at DuplexWrapper.<anonymous> (/Users/arve/Projects/static-module/node_modules/duplexer2/index.js:29:14)
```