### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/bench/input.js
+++ b/bench/input.js
@@ -5165,7 +5165,7 @@ pp$8.readEscapedChar = function(inTemplate) {
     return ""
   default:
     if (ch >= 48 && ch <= 55) {
-      var octalStr = this.input.substr(this.pos - 1, 3).match(/^[0-7]+/)[0];
+      var octalStr = this.input.slice(this.pos - 1, this.pos + 2).match(/^[0-7]+/)[0];
       var octal = parseInt(octalStr, 8);
       if (octal > 255) {
         octalStr = octalStr.slice(0, -1);


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.